### PR TITLE
[#11] 친구 목록 화면에 뷰페이저 적용

### DIFF
--- a/app/src/main/java/com/w36495/senty/view/entity/FriendGroup.kt
+++ b/app/src/main/java/com/w36495/senty/view/entity/FriendGroup.kt
@@ -37,5 +37,6 @@ data class FriendGroup(
     companion object {
         private val DEFAULT_COLOR = Color(0xFFCED4DA).value
         val emptyFriendGroup = FriendGroup(name = "")
+        val allFriendGroup = FriendGroup(name = "전체")
     }
 }

--- a/app/src/main/java/com/w36495/senty/view/screen/home/FriendScreen.kt
+++ b/app/src/main/java/com/w36495/senty/view/screen/home/FriendScreen.kt
@@ -2,38 +2,59 @@ package com.w36495.senty.view.screen.home
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Divider
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Group
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRowDefaults
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.google.accompanist.pager.ExperimentalPagerApi
+import com.google.accompanist.pager.HorizontalPager
+import com.google.accompanist.pager.PagerState
+import com.google.accompanist.pager.rememberPagerState
 import com.w36495.senty.util.getTextColorByBackgroundColor
 import com.w36495.senty.view.entity.Friend
+import com.w36495.senty.view.entity.FriendGroup
 import com.w36495.senty.view.ui.component.buttons.SentyOutlinedButtonWithIcon
 import com.w36495.senty.view.ui.component.chips.FriendGroupChip
+import com.w36495.senty.view.ui.theme.Green40
 import com.w36495.senty.viewModel.FriendViewModel
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -43,7 +64,8 @@ fun FriendScreen(
     onClickAddFriend: () -> Unit,
     onClickFriend: (String) -> Unit,
 ) {
-    val friendList by vm.friends.collectAsStateWithLifecycle()
+    val friends by vm.friends.collectAsStateWithLifecycle()
+    val friendGroups by vm.friendGroups.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = {
@@ -61,53 +83,197 @@ fun FriendScreen(
         containerColor = Color.White
     ) { innerPadding ->
         FriendContents(
-            modifier = Modifier.padding(innerPadding),
-            friends = friendList,
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize(),
+            friends = friends,
+            friendGroups = friendGroups,
             onClickFriend = { friend -> onClickFriend(friend.friendDetail.id) },
-            onClickAddFriend = {
-                onClickAddFriend()
-            }
+            onClickAddFriend = { onClickAddFriend() },
+            onChangeFriendGroup = { vm.getFriendsByFriendGroup(it) },
+            onChangeFriendGroupAll = { vm.getFriendsByFriendGroup(null) }
         )
     }
 }
 
+@OptIn(ExperimentalPagerApi::class)
 @Composable
 private fun FriendContents(
     modifier: Modifier = Modifier,
     friends: List<Friend>,
+    friendGroups: List<FriendGroup>,
     onClickFriend: (Friend) -> Unit,
-    onClickAddFriend: () -> Unit
+    onClickAddFriend: () -> Unit,
+    onChangeFriendGroupAll: () -> Unit,
+    onChangeFriendGroup: (FriendGroup) -> Unit,
 ) {
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(horizontal = 16.dp)
-            .verticalScroll(rememberScrollState())
-    ) {
+    val viewPagerState = rememberPagerState(
+        pageCount = friendGroups.size,
+        initialPage = 0,
+        infiniteLoop = true,
+    )
+
+    LaunchedEffect(viewPagerState.currentPage) {
+        when (viewPagerState.currentPage) {
+            0 -> { onChangeFriendGroupAll() }
+            else -> { onChangeFriendGroup(friendGroups[viewPagerState.currentPage]) }
+        }
+    }
+
+    Column(modifier = modifier.fillMaxSize()) {
         SentyOutlinedButtonWithIcon(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
             text = "친구 등록",
             icon = Icons.Default.Add,
             onClick = { onClickAddFriend() }
         )
 
-        friends.forEachIndexed { index, friendEntity ->
-            FriendItemContent(
-                friend = friendEntity,
-                onClickFriend = { onClickFriend(it) }
-            )
+        Spacer(modifier = Modifier.height(4.dp))
 
-            if (index < friends.lastIndex) {
-                Divider()
+        FriendTopTabLow(
+            modifier = Modifier.fillMaxWidth(),
+            friendGroups = friendGroups,
+            pagerState = viewPagerState
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        FriendViewPager(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp),
+            pagerState = viewPagerState,
+            friendList = friends,
+            friendGroup = friendGroups[viewPagerState.currentPage],
+            onClickFriend = { onClickFriend(it) }
+        )
+    }
+}
+
+@OptIn(ExperimentalPagerApi::class)
+@Composable
+private fun FriendTopTabLow(
+    modifier: Modifier = Modifier,
+    friendGroups: List<FriendGroup>,
+    pagerState: PagerState,
+) {
+    val currentTabIndex = pagerState.currentPage
+    val coroutineScope = rememberCoroutineScope()
+
+    ScrollableTabRow(
+        modifier = modifier,
+        selectedTabIndex = currentTabIndex,
+        contentColor = Color.Black,
+        containerColor = Color.White,
+        indicator = {
+            TabRowDefaults.SecondaryIndicator(
+                modifier = Modifier.tabIndicatorOffset(it[currentTabIndex]),
+                color = Green40
+            )
+        },
+        edgePadding = 0.dp
+    ) {
+        friendGroups.forEachIndexed { index, friendGroup ->
+            Tab(
+                modifier = Modifier.clip(RoundedCornerShape(10.dp)),
+                selected = currentTabIndex == index,
+                onClick = {
+                    coroutineScope.launch {
+                        pagerState.animateScrollToPage(index)
+                    }
+                },
+            ) {
+                Text(
+                    text = friendGroup.name,
+                    modifier = Modifier.padding(
+                        vertical = 12.dp,
+                        horizontal = 16.dp
+                    ),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = if (index == currentTabIndex) Green40 else MaterialTheme.colorScheme.onSurface
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalPagerApi::class)
+@Composable
+private fun FriendViewPager(
+    modifier: Modifier = Modifier,
+    pagerState: PagerState,
+    friendList: List<Friend>,
+    friendGroup: FriendGroup,
+    onClickFriend: (Friend) -> Unit,
+) {
+    HorizontalPager(
+        modifier = modifier,
+        state = pagerState
+    ) {
+        when (pagerState.currentPage) {
+            0 -> {
+                FriendViewPagerItemContainer(
+                    friendList = friendList,
+                    friendGroup = friendGroup,
+                    isShowFriendGroup = true,
+                    onClickFriend = onClickFriend
+                )
+            }
+            else -> {
+                FriendViewPagerItemContainer(
+                    friendList = friendList,
+                    friendGroup = friendGroup,
+                    isShowFriendGroup = false,
+                    onClickFriend = onClickFriend
+                )
             }
         }
     }
 }
 
 @Composable
-fun FriendItemContent(
+fun FriendViewPagerItemContainer(
+    modifier: Modifier = Modifier,
+    friendList: List<Friend>,
+    friendGroup: FriendGroup,
+    isShowFriendGroup: Boolean,
+    onClickFriend: (Friend) -> Unit,
+) {
+    if (friendList.isEmpty()) {
+        EmptyFriendInGroup(
+            modifier = Modifier.fillMaxSize(),
+            friendGroup = friendGroup
+        )
+    } else {
+        Box(modifier = modifier.fillMaxSize()) {
+            LazyColumn(
+                state = rememberLazyListState(),
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                itemsIndexed(friendList) {index, friend ->
+                    FriendViewPagerItem(
+                        friend = friend,
+                        isShowFriendGroup = isShowFriendGroup,
+                        onClickFriend = { onClickFriend(friend) }
+                    )
+
+                    if (index != friendList.lastIndex) {
+                        HorizontalDivider()
+                    }
+                }
+
+            }
+        }
+    }
+}
+
+@Composable
+fun FriendViewPagerItem(
     modifier: Modifier = Modifier,
     friend: Friend,
+    isShowFriendGroup: Boolean = false,
     onClickFriend: (Friend) -> Unit
 ) {
     Column(
@@ -117,14 +283,17 @@ fun FriendItemContent(
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = if (isShowFriendGroup) Arrangement.SpaceBetween else Arrangement.End
         ) {
-            FriendGroupChip(
-                text = friend.friendDetail.friendGroup.name,
-                chipColor = friend.friendDetail.friendGroup.color,
-                textColor = friend.friendDetail.friendGroup.color.getTextColorByBackgroundColor()
-            )
+            if (isShowFriendGroup) {
+                FriendGroupChip(
+                    text = friend.friendDetail.friendGroup.name,
+                    chipColor = friend.friendDetail.friendGroup.color,
+                    textColor = friend.friendDetail.friendGroup.color.getTextColorByBackgroundColor()
+                )
+            }
+
             Text(
                 text = if (friend.friendDetail.birthday.isEmpty()) "" else friend.friendDetail.displayBirthdayOnlyDate(),
                 style = MaterialTheme.typography.labelLarge,
@@ -168,5 +337,26 @@ fun FriendItemContent(
                 modifier = Modifier.padding(horizontal = 4.dp)
             )
         }
+    }
+}
+
+@Composable
+private fun EmptyFriendInGroup(
+    modifier: Modifier = Modifier,
+    friendGroup: FriendGroup,
+) {
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            textAlign = TextAlign.Center,
+            text = if (friendGroup == FriendGroup.allFriendGroup) {
+                "등록된 친구가 존재하지 않습니다.\n 새로운 친구를 등록해보세요."
+            } else {
+                "${friendGroup.name} 그룹의 친구가 존재하지 않습니다.\n 새로운 친구를 등록해보세요."
+            },
+            style = MaterialTheme.typography.labelLarge,
+        )
     }
 }

--- a/app/src/main/java/com/w36495/senty/view/ui/component/chips/FriendGorupChip.kt
+++ b/app/src/main/java/com/w36495/senty/view/ui/component/chips/FriendGorupChip.kt
@@ -10,10 +10,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
-@Preview(showBackground = true)
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun FriendGroupChip(
@@ -22,14 +20,15 @@ fun FriendGroupChip(
     chipColor: String? = null,
     textColor: Int? = null,
 ) {
-    Chip(onClick = { },
+    Chip(
+        modifier = modifier,
+        onClick = { },
         enabled = false,
         shape = RoundedCornerShape(10.dp),
         colors = ChipDefaults.chipColors(
             backgroundColor = chipColor?.let { Color(it.toULong()) } ?: Color.Unspecified,
             disabledBackgroundColor = chipColor?.let { Color(it.toULong()) } ?: Color.Unspecified,
-        )
-
+        ),
     ) {
         Text(
             text = text ?: "",

--- a/app/src/main/java/com/w36495/senty/viewModel/FriendViewModel.kt
+++ b/app/src/main/java/com/w36495/senty/viewModel/FriendViewModel.kt
@@ -6,12 +6,15 @@ import com.w36495.senty.domain.repository.FriendGroupRepository
 import com.w36495.senty.domain.repository.FriendRepository
 import com.w36495.senty.domain.repository.GiftRepository
 import com.w36495.senty.view.entity.Friend
+import com.w36495.senty.view.entity.FriendGroup
 import com.w36495.senty.view.entity.gift.GiftType
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -20,27 +23,60 @@ class FriendViewModel @Inject constructor(
     private val friendGroupRepository: FriendGroupRepository,
     private val giftRepository: GiftRepository,
 ) : ViewModel() {
-    val friends: StateFlow<List<Friend>> = combine(
-        friendRepository.getFriends(),
-        friendGroupRepository.getFriendGroups()
-    ) { friends, groups ->
-        friends.map { friend ->
-            val group = groups.find { it.id == friend.friendGroup.id }
+    private var _friends = MutableStateFlow<List<Friend>>(emptyList())
+    val friends = _friends.asStateFlow()
+    private var _friendGroups = MutableStateFlow(listOf(FriendGroup.allFriendGroup))
+    val friendGroups = _friendGroups.asStateFlow()
 
-            Friend(friendDetail = friend.copy(friendGroup = group!!))
+    init {
+        loadFriendGroups()
+        loadFriends(groupFilter = null)
+    }
+
+    fun getFriendsByFriendGroup(friendGroup: FriendGroup?) {
+        loadFriends(friendGroup)
+    }
+
+    private fun loadFriends(groupFilter: FriendGroup?) {
+        viewModelScope.launch {
+            combine(
+                friendRepository.getFriends(),
+                friendGroupRepository.getFriendGroups(),
+                giftRepository.getGifts()
+            ) { friends, groups, gifts ->
+                friends.map { friend ->
+                    val group = groups.find { group -> group.id == friend.friendGroup.id }
+                    val sentGiftCount = gifts.filter { it.friend.id == friend.id }.count { it.giftType == GiftType.SENT }
+                    val receivedGiftCount = gifts.filter { it.friend.id == friend.id }.count { it.giftType == GiftType.RECEIVED }
+
+                    Friend(
+                        friendDetail = friend.copy(friendGroup = group!!),
+                        sentGiftCount = sentGiftCount,
+                        receivedGiftCount = receivedGiftCount
+                    )
+                }
+            }
+                .map {
+                    if (groupFilter != null) {
+                        it.filter { friend ->
+                            friend.friendDetail.friendGroup.id == groupFilter.id
+                        }
+                    } else it
+                }
+                .collect { collectFriends ->
+                    _friends.update { collectFriends.toList() }
+                }
         }
     }
-        .combine(giftRepository.getGifts()) { friends, gifts ->
-            friends.map { friend ->
-                friend.copy(
-                    sentGiftCount = gifts.filter { it.friendId == friend.friendDetail.id }.count { it.giftType == GiftType.SENT },
-                    receivedGiftCount = gifts.filter { it.friendId == friend.friendDetail.id }.count { it.giftType == GiftType.RECEIVED }
-                )
-            }
+
+    private fun loadFriendGroups() {
+        viewModelScope.launch {
+            friendGroupRepository.getFriendGroups()
+                .collect {
+                    _friendGroups.update { oldFriendGroups ->
+                        oldFriendGroups.plus(it.toList())
+                    }
+                }
         }
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = emptyList()
-        )
+    }
 }


### PR DESCRIPTION
## ISSUE
- #11 

## Done
- [x] 탭+뷰페이저 적용
- [x] 그룹에 따라 그룹에 해당되는 친구 목록 표시

## Discuss
**Tab을 클릭할 때마다 네트워크 통신을 하는 것이 괜찮은 방법인지?**

## Result
|`Before`|`After`|
|:--:|:--:|
|<img src="https://github.com/user-attachments/assets/455632d2-c48c-4121-8ccd-ead067364e33" width=50%>|![친구목록](https://github.com/user-attachments/assets/40475252-8b46-4a21-bd80-cd7d3a0fb03b)|
