### PR TITLE
[#10] 캘린더에 모든 일정들 표시

### DIFF
--- a/app/src/main/java/com/w36495/senty/data/domain/ScheduleEntity.kt
+++ b/app/src/main/java/com/w36495/senty/data/domain/ScheduleEntity.kt
@@ -2,12 +2,13 @@ package com.w36495.senty.data.domain
 
 import com.w36495.senty.util.DateUtil
 import com.w36495.senty.view.entity.Schedule
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonNames
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class ScheduleEntity(
-    val id: String = "",
     val title: String,
     val date: String,
     val location: String,
@@ -26,7 +27,5 @@ data class ScheduleEntity(
         time = time,
         memo = memo,
         isPast = isPast
-    ).apply {
-        setId(this@ScheduleEntity.id)
-    }
+    )
 }

--- a/app/src/main/java/com/w36495/senty/view/entity/Schedule.kt
+++ b/app/src/main/java/com/w36495/senty/view/entity/Schedule.kt
@@ -38,7 +38,6 @@ data class Schedule(
     }
 
     fun toDataEntity() = ScheduleEntity(
-        id = this@Schedule.id,
         title = title,
         date = date,
         location = location,
@@ -46,6 +45,10 @@ data class Schedule(
         memo = memo,
         isPast = isPast,
     )
+
+    override fun toString(): String {
+        return "Schedule(id=$id, title=$title, date=$date, location=$location, time=$time, memo=$memo, isPast=$isPast)"
+    }
 
     companion object {
         val emptySchedule = Schedule(title = "", date = "")

--- a/app/src/main/java/com/w36495/senty/view/screen/anniversary/AnniversaryCalendar.kt
+++ b/app/src/main/java/com/w36495/senty/view/screen/anniversary/AnniversaryCalendar.kt
@@ -1,0 +1,285 @@
+package com.w36495.senty.view.screen.anniversary
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.cheonjaeung.compose.grid.SimpleGridCells
+import com.cheonjaeung.compose.grid.VerticalGrid
+import com.google.accompanist.pager.ExperimentalPagerApi
+import com.google.accompanist.pager.HorizontalPager
+import com.google.accompanist.pager.PagerState
+import com.google.accompanist.pager.rememberPagerState
+import com.w36495.senty.view.entity.Schedule
+import com.w36495.senty.view.ui.theme.Green40
+import org.threeten.bp.DayOfWeek
+import org.threeten.bp.LocalDate
+import org.threeten.bp.format.DateTimeFormatter
+import org.threeten.bp.format.TextStyle
+import java.util.Locale
+
+@OptIn(ExperimentalPagerApi::class)
+@Composable
+fun AnniversaryCalendar(
+    schedules: List<Schedule>,
+    onSelectedDate: (Int, Int, Int) -> Unit,
+) {
+    val initialDate: LocalDate = LocalDate.now()
+    var currentDate by remember { mutableStateOf(initialDate) }
+
+    val initialPage = (currentDate.year - CalendarRange.START_YEAR) * 12 + currentDate.monthValue - 1
+    var currentPage by remember { mutableIntStateOf(initialPage) }
+
+    val pagerState = rememberPagerState(
+        initialPage = currentPage,
+        pageCount = (CalendarRange.LAST_YEAR - CalendarRange.START_YEAR) * 12
+    )
+
+    LaunchedEffect(pagerState.currentPage) {
+        val changeMonth = (pagerState.currentPage - currentPage).toLong()
+        val newDate = currentDate.plusMonths(changeMonth)
+        currentDate = newDate
+        currentPage = pagerState.currentPage
+    }
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.Center,
+    ) {
+        CalendarHeader(
+            modifier = Modifier.fillMaxWidth(),
+            currentDate = currentDate,
+            onClickNextMonth = {
+                val changeMonth = currentDate.plusMonths(1)
+                currentDate = changeMonth
+            },
+            onClickPreviousMonth = {
+                val changeMonth = currentDate.minusMonths(1)
+                currentDate = changeMonth
+            },
+            onClickMoreMonth = {
+                // TODO : 년/월 선택 다이얼로그
+            }
+        )
+
+        CalendarDayOfWeek(
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        CalendarDays(
+            modifier = Modifier.fillMaxWidth(),
+            pagerState = pagerState,
+            currentDate = currentDate,
+            schedules = schedules,
+            onSelectedDate = { day ->
+                val year = currentDate.year
+                val month = currentDate.monthValue
+                onSelectedDate(year, month, day)
+            }
+        )
+    }
+}
+
+@Composable
+private fun CalendarHeader(
+    modifier: Modifier = Modifier,
+    currentDate: LocalDate,
+    onClickMoreMonth: () -> Unit,
+    onClickPreviousMonth: () -> Unit,
+    onClickNextMonth: () -> Unit,
+) {
+    val formattedDate = currentDate.format(DateTimeFormatter.ofPattern("yyyy년 MM월"))
+
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onClickPreviousMonth) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                contentDescription = null
+            )
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = formattedDate,
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Medium
+            )
+            Icon(
+                imageVector = Icons.Default.ArrowDropDown,
+                contentDescription = null,
+                modifier = Modifier
+                    .clip(CircleShape)
+                    .clickable { onClickMoreMonth() }
+            )
+        }
+
+        IconButton(onClick = onClickNextMonth) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null
+            )
+        }
+    }
+}
+
+@Composable
+private fun CalendarDayOfWeek(
+    modifier: Modifier = Modifier,
+) {
+    val dayOfTheWeek = listOf(
+        DayOfWeek.MONDAY,
+        DayOfWeek.TUESDAY,
+        DayOfWeek.WEDNESDAY,
+        DayOfWeek.THURSDAY,
+        DayOfWeek.FRIDAY,
+        DayOfWeek.SATURDAY,
+        DayOfWeek.SUNDAY
+    )
+
+    Row(
+        modifier = modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        dayOfTheWeek.forEach {
+            Text(
+                modifier = Modifier.weight(1f),
+                textAlign = TextAlign.Center,
+                text = it.getDisplayName(TextStyle.NARROW, Locale.KOREA),
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold,
+                color = if (it == DayOfWeek.SUNDAY) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalPagerApi::class)
+@Composable
+private fun CalendarDays(
+    modifier: Modifier = Modifier,
+    pagerState: PagerState,
+    currentDate: LocalDate,
+    schedules: List<Schedule>,
+    onSelectedDate: (Int) -> Unit,
+) {
+    val days by remember(currentDate) {
+        mutableStateOf(IntRange(1, currentDate.lengthOfMonth()).toList())
+    }
+    val firstDayOfWeek by remember(currentDate) {
+        mutableIntStateOf(currentDate.dayOfWeek.value)
+    }
+
+    val dayOfSchedules = schedules.filter {
+        it.getYear() == currentDate.year && it.getMonth() == currentDate.monthValue
+    }.map { it.getDay() }
+
+    HorizontalPager(
+        state = pagerState,
+        dragEnabled = true
+    ) {page ->
+        VerticalGrid(
+            columns = SimpleGridCells.Fixed(7),
+            modifier = modifier.padding(horizontal = 16.dp)
+        ) {
+            for (i in 1 until firstDayOfWeek) {
+                EmptyDayBox()
+            }
+
+            days.forEach { day ->
+                DayBox(
+                    modifier = Modifier.padding(bottom = 8.dp),
+                    day = day,
+                    isToday = (currentDate.year == LocalDate.now().year && currentDate.monthValue == LocalDate.now().monthValue && day == LocalDate.now().dayOfMonth),
+                    hasSchedule = dayOfSchedules.contains(day),
+                    onSelectedDate = { onSelectedDate(day) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DayBox(
+    modifier: Modifier = Modifier,
+    day: Int,
+    isToday: Boolean,
+    hasSchedule: Boolean,
+    onSelectedDate: () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .wrapContentSize()
+            .size(32.dp)
+            .background(
+                color = if (isToday) Green40 else Color.Transparent,
+                shape = CircleShape
+            )
+            .border(
+                border = BorderStroke(
+                    width = 1.dp,
+                    color = if (hasSchedule) MaterialTheme.colorScheme.onSurface.copy(0.3f) else Color.Transparent),
+                shape = CircleShape
+            )
+            .clip(CircleShape)
+            .clickable {
+                onSelectedDate()
+            },
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = day.toString(),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.labelLarge,
+            color = if (isToday) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
+
+@Composable
+private fun EmptyDayBox(
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier)
+}
+
+object CalendarRange {
+    const val START_YEAR = 1070
+    const val LAST_YEAR = 2100
+}

--- a/app/src/main/java/com/w36495/senty/view/screen/anniversary/AnniversaryCalendar.kt
+++ b/app/src/main/java/com/w36495/senty/view/screen/anniversary/AnniversaryCalendar.kt
@@ -42,6 +42,7 @@ import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.PagerState
 import com.google.accompanist.pager.rememberPagerState
 import com.w36495.senty.view.entity.Schedule
+import com.w36495.senty.view.ui.component.dialogs.DateWheelPickerDialog
 import com.w36495.senty.view.ui.theme.Green40
 import org.threeten.bp.DayOfWeek
 import org.threeten.bp.LocalDate
@@ -88,8 +89,8 @@ fun AnniversaryCalendar(
                 val changeMonth = currentDate.minusMonths(1)
                 currentDate = changeMonth
             },
-            onClickMoreMonth = {
-                // TODO : 년/월 선택 다이얼로그
+            onChangeCurrentDate = { year, month ->
+                currentDate = LocalDate.of(year, month, currentDate.dayOfMonth)
             }
         )
 
@@ -115,11 +116,24 @@ fun AnniversaryCalendar(
 private fun CalendarHeader(
     modifier: Modifier = Modifier,
     currentDate: LocalDate,
-    onClickMoreMonth: () -> Unit,
+    onChangeCurrentDate: (Int, Int) -> Unit,
     onClickPreviousMonth: () -> Unit,
     onClickNextMonth: () -> Unit,
 ) {
     val formattedDate = currentDate.format(DateTimeFormatter.ofPattern("yyyy년 MM월"))
+    var showDateWheelPicker by remember { mutableStateOf(false) }
+
+    if (showDateWheelPicker) {
+        DateWheelPickerDialog(
+            initialYear = currentDate.year,
+            initialMonth = currentDate.monthValue,
+            onDismiss = { showDateWheelPicker = false },
+            onSelectedDate = { year, month ->
+                onChangeCurrentDate(year, month)
+                showDateWheelPicker = false
+            }
+        )
+    }
 
     Row(
         modifier = modifier,
@@ -146,7 +160,7 @@ private fun CalendarHeader(
                 contentDescription = null,
                 modifier = Modifier
                     .clip(CircleShape)
-                    .clickable { onClickMoreMonth() }
+                    .clickable { showDateWheelPicker = true }
             )
         }
 
@@ -254,7 +268,8 @@ private fun DayBox(
             .border(
                 border = BorderStroke(
                     width = 1.dp,
-                    color = if (hasSchedule) MaterialTheme.colorScheme.onSurface.copy(0.3f) else Color.Transparent),
+                    color = if (hasSchedule) MaterialTheme.colorScheme.onSurface.copy(0.3f) else Color.Transparent
+                ),
                 shape = CircleShape
             )
             .clip(CircleShape)
@@ -280,6 +295,8 @@ private fun EmptyDayBox(
 }
 
 object CalendarRange {
-    const val START_YEAR = 1070
+    const val START_YEAR = 1970
     const val LAST_YEAR = 2100
+    const val START_MONTH = 1
+    const val LAST_MONTH = 12
 }

--- a/app/src/main/java/com/w36495/senty/view/ui/component/dialogs/DateWheelPickerDialog.kt
+++ b/app/src/main/java/com/w36495/senty/view/ui/component/dialogs/DateWheelPickerDialog.kt
@@ -1,0 +1,247 @@
+package com.w36495.senty.view.ui.component.dialogs
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.w36495.senty.view.screen.anniversary.CalendarRange
+import com.w36495.senty.view.ui.component.buttons.SentyFilledButton
+import com.w36495.senty.view.ui.theme.Green40
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DateWheelPickerDialog(
+    modifier: Modifier = Modifier,
+    initialYear: Int,
+    initialMonth: Int,
+    onDismiss: () -> Unit,
+    onSelectedDate: (Int, Int) -> Unit,
+) {
+    val yearRange = (CalendarRange.START_YEAR..CalendarRange.LAST_YEAR).toList()
+    val monthRange = (CalendarRange.START_MONTH..CalendarRange.LAST_MONTH).toList()
+    var currentYear by remember { mutableIntStateOf(initialYear) }
+    var currentMonth by remember { mutableIntStateOf(initialMonth) }
+
+    Dialog(onDismissRequest = { onDismiss() }) {
+        Card(
+            modifier = modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.onPrimary
+            )
+        ) {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                CenterAlignedTopAppBar(
+                    title = { },
+                    actions = {
+                        IconButton(onClick = { onDismiss() }) {
+                            Icon(imageVector = Icons.Default.Close, contentDescription = null)
+                        }
+                    },
+                    colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.onPrimary
+                    )
+                )
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                ) {
+                    DateWheelPicker(
+                        startIndex = yearRange.indexOf(initialYear),
+                        items = yearRange,
+                        modifier = Modifier.weight(1f),
+                        onSelectedItem = { selectedYear ->
+                            currentYear = selectedYear
+                        }
+                    )
+
+                    Text(
+                        text = "년",
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(0.5f)
+                            .align(Alignment.CenterVertically),
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Medium,
+                    )
+
+                    DateWheelPicker(
+                        startIndex = monthRange.indexOf(initialMonth),
+                        items = monthRange,
+                        modifier = Modifier.weight(0.5f),
+                        dividerHorizontalPadding = 8.dp,
+                        onSelectedItem = { selectedMonth ->
+                            currentMonth = selectedMonth
+                        }
+                    )
+
+                    Text(
+                        text = "월",
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(0.5f)
+                            .padding(start = 8.dp)
+                            .align(Alignment.CenterVertically),
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Medium,
+                    )
+                }
+
+                SentyFilledButton(
+                    text = "선택",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    onClick = { onSelectedDate(currentYear, currentMonth) },
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun DateWheelPicker(
+    modifier: Modifier = Modifier,
+    pickerState: PickerState = rememberPickerState(),
+    items: List<Int>,
+    startIndex: Int = 0,
+    visibleItemCount: Int = 5,
+    dividerColor: Color = Green40,
+    dividerHorizontalPadding: Dp = 16.dp,
+    onSelectedItem: @Composable (Int) -> Unit,
+) {
+    val visibleItemsMiddle = visibleItemCount / 2
+    val listScrollCount = Int.MAX_VALUE
+    val listScrollMiddle = listScrollCount / 2
+    val listStartIndex = listScrollMiddle - listScrollMiddle % items.size - visibleItemsMiddle + startIndex
+
+    fun getItem(index: Int) = items[index % items.size]
+
+    val scrollState = rememberLazyListState(initialFirstVisibleItemIndex = listStartIndex)
+    val flingBehavior = rememberSnapFlingBehavior(lazyListState = scrollState)
+
+    var itemHeightPixel by remember { mutableIntStateOf(0) }
+    val itemHeightToDp = pixelsToDp(pixels = itemHeightPixel)
+
+    val fadingEdgeGradient = remember {
+        Brush.verticalGradient(
+            0f to Color.Transparent,
+            0.5f to Color.Black,
+            1f to Color.Transparent
+        )
+    }
+
+    LaunchedEffect(scrollState) {
+        snapshotFlow { scrollState.firstVisibleItemIndex }
+            .map { index -> getItem(index + visibleItemsMiddle) }
+            .distinctUntilChanged()
+            .collect { item ->
+                pickerState.selectedItem = item
+            }
+    }
+
+    Box(modifier = modifier.wrapContentWidth()) {
+        LazyColumn(
+            state = scrollState,
+            flingBehavior = flingBehavior,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(itemHeightToDp * visibleItemCount)
+                .fadingEdge(fadingEdgeGradient)
+        ) {
+            items(listScrollCount) { index ->
+                Text(
+                    text = getItem(index).toString(),
+                    textAlign = TextAlign.Center,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier
+                        .onSizeChanged { size -> itemHeightPixel = size.height }
+                        .padding(vertical = 4.dp)
+                )
+
+            }
+        }
+        HorizontalDivider(
+            color = dividerColor,
+            thickness = 2.dp,
+            modifier = Modifier
+                .padding(horizontal = dividerHorizontalPadding)
+                .offset(y = itemHeightToDp * visibleItemsMiddle)
+        )
+        HorizontalDivider(
+            color = dividerColor,
+            thickness = 2.dp,
+            modifier = Modifier
+                .padding(horizontal = dividerHorizontalPadding)
+                .offset(y = itemHeightToDp * (visibleItemsMiddle + 1))
+        )
+    }
+
+    onSelectedItem(pickerState.selectedItem)
+}
+
+class PickerState {
+    var selectedItem by mutableIntStateOf(0)
+}
+
+@Composable
+private fun rememberPickerState() = remember { PickerState() }
+
+private fun Modifier.fadingEdge(brush: Brush) = this
+    .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+    .drawWithContent {
+        drawContent()
+        drawRect(brush = brush, blendMode = BlendMode.DstIn)
+    }
+
+@Composable
+private fun pixelsToDp(pixels: Int) = with(LocalDensity.current) { pixels.toDp() }


### PR DESCRIPTION
## Issue
- #10 

## Todo
- [x] 커스텀 캘린더로 변경
- [x] 배경색으로 모든 일정 표시 -> Border로 표시
- [x] `새로운 캘린더 등록하기` 버튼 하단에 선택한 날짜 표시
- [x] 년/월 선택 Custom Date Wheel Picker 로 변경 

**기존 캘린더 -> 커스텀 캘린더로 변경하고자 하는 이유**
- 영어보다 한글이 표기되어있으면 좋을 것 같음
- 년/월을 선택하는 것이 불편하다고 생각되었음

## Result
### 수정 전 캘린더
|`캘린더`|`년/월 선택`|
|:--:|:--:|
|![캘린더](https://github.com/user-attachments/assets/d4f2b12b-337f-4b8d-abea-7e6a46b3befd)|![년/월 선택](https://github.com/user-attachments/assets/b5ab23be-1f7e-41f0-b0dc-5acd6de477a7)|

### 수정 후 캘린더
|`캘린더`|`기존 일정 표시`|`년/월 선택`|
|:--:|:--:|:--:|
|![캘린더](https://github.com/user-attachments/assets/65e6e238-b429-4f1e-a3cf-f6320ac4a4db)|![기존일정 표시](https://github.com/user-attachments/assets/e5033950-d8ac-4259-a23c-045c2c488a5a)|![년월피커](https://github.com/user-attachments/assets/3172628b-a27f-48a5-9de6-add6deeebb76)|
