### PR TITLE
[FIX] 회원가입 후, BackStack에 회원가입이 남아있지 않도록 수정

### DIFF
--- a/app/src/main/java/com/w36495/senty/view/screen/login/navigation/LoginNavigation.kt
+++ b/app/src/main/java/com/w36495/senty/view/screen/login/navigation/LoginNavigation.kt
@@ -39,7 +39,13 @@ fun NavGraphBuilder.authNavGraph(
     composable<Route.SignUp> {
         SignUpRoute(
             padding = padding,
-            moveToLogin = { navController.navigateToLogin() },
+            moveToLogin = {
+                val navOptions = NavOptions.Builder().apply {
+                    setPopUpTo<Route.Login>(true)
+                }.build()
+
+                navController.navigateToLogin(navOptions)
+            },
             onBackPressed = { navController.popBackStack() },
             onShowGlobalErrorSnackBar = onShowGlobalErrorSnackBar,
         )


### PR DESCRIPTION
## ISSUE
- 회원가입 후, 로그인 화면에서 뒤로가기 버튼을 눌렀을 때 회원가입 화면으로 돌아가는 문제

## 해결
- navOptions을 사용하여 BackStack에서 SignUp 제거되도록 적용

## ScreenShots
|`수정 전`|`수정 후`|
|:--:|:--:|
|![수정전](https://github.com/user-attachments/assets/679a21f3-3e50-49c9-a0d1-ea16c25a98d7)|![수정후](https://github.com/user-attachments/assets/86888e7f-a37e-4786-9429-5eeadeba2c09)|
|- 뒤로가기 클릭 시, 회원가입 화면으로 이동됨|- 뒤로가기 클릭 시, 종료 팝업 표시|
